### PR TITLE
feat: add build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = "ezdxt",
+    .version = "0.1.1",
+    .dependencies = .{
+    },
+    .paths = .{
+        "src",
+        "build.zig",
+        "build.zig.zon",
+    },
+}


### PR DESCRIPTION
Thank you for merging my zig-0.13.0 code.
I also created `build.zig.zon` template for `zig fetch` works. (Please check how this works such as [zig-lz4's #installation](https://github.com/SnorlaxAssist/zig-lz4?tab=readme-ov-file#installation))

If you want to change versioning, please modify code of this PR or create another commit as you like.